### PR TITLE
add action to check pxt json files are valid

### DIFF
--- a/.github/workflows/check-pxt-json.yml
+++ b/.github/workflows/check-pxt-json.yml
@@ -1,0 +1,23 @@
+name: Check pxt.json
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Node
+      uses: actions/setup-node@v1
+
+    - name: Validate / fix pxt.json
+      run: node ./.github/workflows/json-check.js
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        commit-message: Removing missing files from pxt.json
+        title: '🐛 missing files listed in pxt.json 🐛'

--- a/.github/workflows/json-check.js
+++ b/.github/workflows/json-check.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+
+const json = JSON.parse(fs.readFileSync('pxt.json'));
+const missing = [];
+const existing = [];
+
+for (const file of (json.files || [])) {
+    if (fs.existsSync(file)) {
+        existing.push(file);
+    } else {
+        missing.push(file);
+    }
+}
+
+if (missing.length) {
+    console.warn(`pxt.json lists files that are missing:
+    ${missing.join(",\n    ")}
+`);
+    json.files = existing;
+    fs.writeFileSync('pxt.json', JSON.stringify(json, undefined, 4));
+}


### PR DESCRIPTION
Quick starter action to check that the files listed in pxt.json exist, and make a pr to fix it if they do not. (This just checks the files field, but can add a check for `testFiles` / `fileDependencies` if we want to too)